### PR TITLE
[KFI] FIX: SmtpClient in using block.

### DIFF
--- a/src/Notification/NotificationSender.cs
+++ b/src/Notification/NotificationSender.cs
@@ -13,15 +13,14 @@ namespace SenseNet.Notification
     internal class NotificationSender
     {
         private static bool _mailSendingInProgress;
-        private static SmtpClient _smtpClient;
         private static readonly bool _isSmtpConfigured;
         
         internal static bool TestMode { get; set; }
 
         static NotificationSender()
         {
-            _smtpClient = new SmtpClient();
-            _isSmtpConfigured = !String.IsNullOrEmpty(_smtpClient.Host);
+            using (var smtpClient = new SmtpClient())
+                _isSmtpConfigured = !String.IsNullOrEmpty(smtpClient.Host);
             _mailSendingInProgress = false;
             TestMode = false;
         }
@@ -197,7 +196,8 @@ namespace SenseNet.Notification
                 Debug.WriteLine("#Notification> Message sent, subject: " + message.Subject);
             else
             {
-                _smtpClient.Send(message.GenerateMailMessage());
+                using (var smtpClient = new SmtpClient())
+                    smtpClient.Send(message.GenerateMailMessage());
 
                 Debug.WriteLine("#Notification> Message sent, subject: " + message.Subject);
             }


### PR DESCRIPTION
Please review and merge to "develop".

Note that the NotificationSender's static ctor only checks the configuration. In this case, the static pinned instance does not necessary. The sending always uses a new instance so finally, the pinned static instance is deletable.